### PR TITLE
Remove the need for NSG

### DIFF
--- a/byos/containers/deploy/deploy.sh
+++ b/byos/containers/deploy/deploy.sh
@@ -138,12 +138,15 @@ then
 fi
 
 # Create VM
-az vm create -n internal-vm -g $teamRG --admin-username azureuser --generate-ssh-keys --public-ip-address "" --image UbuntuLTS --vnet-name vnet --subnet vm-subnet
+az vm create -n internal-vm -g $teamRG --admin-username azureuser --generate-ssh-keys --public-ip-address "" --image UbuntuLTS --vnet-name vnet --subnet vm-subnet --nsg-rule NONE
 
 if [ $? == 0 ];
 then
     echo "VM created successfully in subnet"
 fi
+
+# Deallocate the VM as it is only used in Challenge 3
+az vm deallocate -n internal-vm -g $teamRG
 
 # Create Azure SQL Server instance
 echo "Creating Azure SQL Server instance..."


### PR DESCRIPTION
The VM does not need to have an NSG as there is no public IP address associated with it, and some customers have locked down subscriptions that do not allow NSG creation.
The VM does not need to be allocated either until challenge 3, so why not deallocating it after is created?