### PR TITLE
Add restart policy for dataload container

### DIFF
--- a/byos/containers/deploy/deploy.sh
+++ b/byos/containers/deploy/deploy.sh
@@ -246,7 +246,8 @@ registryPassword="$(az acr credential show -n $registryName -g $teamRG --query '
 registryLoginServer="$registryName.azurecr.io"
 
 echo "Loading data in SQL database..."
-az container create -g $proctorRG --name dataload --image $registryLoginServer/dataload:1.0 --registry-login-server $registryLoginServer --registry-username $registryName --registry-password $registryPassword \
+az container create -g $proctorRG --name dataload --restart-policy OnFailure \
+    --image $registryLoginServer/dataload:1.0 --registry-login-server $registryLoginServer --registry-username $registryName --registry-password $registryPassword \
     --secure-environment-variables SQLFQDN=$sqlServerName.database.windows.net SQLUSER=$sqlServerUsername SQLPASS=$sqlServerPassword SQLDB=$sqlDBName
 
 logs=$(az container logs -g $proctorRG --name dataload)


### PR DESCRIPTION
Adds a restart policy to prevent the dataload container from rerunning constantly and adding additional cost to the environment deployment.