### PR TITLE
Change '-a' to be a switch only flag

### DIFF
--- a/byos/containers/deploy/deploy.sh
+++ b/byos/containers/deploy/deploy.sh
@@ -18,7 +18,7 @@ declare tenantId=""
 declare randstr=""
 
 # Initialize parameters specified from command line
-while getopts ":l:g:o:f:u:p:s:t:a:" arg; do
+while getopts ":l:g:o:f:u:p:s:t:a" arg; do
     case "${arg}" in
         l)
             region=${OPTARG}


### PR DESCRIPTION
With the opt string used on the while loop, -a must be followed by some value for it to match the case.  Remove the ":" after the 'a' causes it just to be treated like a flag.

WARNING: If -a is used but is not the last option on the line & someone had a value after it to make the flag work (like an empty string ""), it will cause the next option on the line to not be processed.

For example, after patch:
| Command line | Result |
| ---------------- | ------- |
| ./deploy.sh -u "user@domain.tld" -a | azureUserName and createAdUsers are set well |
| ./deploy.sh -u "user@domain.tld" -a "" | azureUserName and createAdUsers are set well |
| ./deploy.sh -a "" -u "user@domain.tld" | createAdUsers is set but azureUserName (and an subsequent options) is never set |