### PR TITLE
Include --bsr for SQL DB

### DIFF
--- a/byos/containers/deploy/deploy.sh
+++ b/byos/containers/deploy/deploy.sh
@@ -205,7 +205,7 @@ then
 
     # Create Azure SQL DB
     echo "Creating Azure SQL DB..."
-    az sql db create -g $teamRG -s $sqlServerName -n $sqlDBName
+    az sql db create -g $teamRG -s $sqlServerName -n $sqlDBName --bsr local
 
 else
     echo "Failed to create SQL Server."


### PR DESCRIPTION
As specified in issue #69 , running the script generates an error at line
`az sql db create` is now prompting for confirmation about backup storage redundancy.

> You have not specified the value for backup storage redundancy
>    which will default to geo-redundant storage. Note that database backups will be geo-replicated
>    to the paired region. To learn more about Azure Paired Regions visit https://aka.ms/azure-ragrs-regions.
>    Do you want to proceed? (y/n):

Adding in a flag (`--bsr local`) to the `az sql db create` command to ensure it doesn't prompt for the during script deployment.