### PR TITLE
Initializing boolean value defaults

### DIFF
--- a/byos/waf/deploy/deploy.sh
+++ b/byos/waf/deploy/deploy.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+deviceLogin=false
+verbose=false
+manualPat=false
+
 while getopts u:p:s:t:dvm flag
 do
     case "${flag}" in


### PR DESCRIPTION
While `$manualPat` would be set to `true` if the `-m` flag is used, it is never set to `false` if the `-m` flag is not included.  This means the first `if` that compares `$manualPat` to `false` is never true as it is `null` so we always fall to the else statement. To ensure all boolean variables referenced by the flags are set to their inverse of the flag, I set all the boolean variables to `false`.