### PR TITLE
Fix routine to find AD domain name

### DIFF
--- a/byos/containers/deploy/deploy.sh
+++ b/byos/containers/deploy/deploy.sh
@@ -271,7 +271,7 @@ fi
 
 if "$createAdUsers"; then
     if [[ -z "$azureUserName" ]]; then
-        azureUserName=$(az account show --query user.name -o tsv)
+        azureUserName=$(az ad signed-in-user show --query 'userPrincipalName' -o tsv )
     fi
     domain=$(cut -d "@" -f 2 <<< $azureUserName)
 


### PR DESCRIPTION
When user login is @live.com @hotmail.com the domain used in these commands were using these logins.
Instead it should use the @accountlive.onmicrosoft.com or @accounthotmail.onmicrosoft.com
The change here find the correct domain name using the user UPN retrieved directly in Azure AD which is something like "account_live.com#EXT#@accountlive.onmicrosoft.com"