### PR TITLE
Use correct path concatination for default params

### DIFF
--- a/byos/modern-data-warehousing/deploy/BYOS-deployAll.ps1
+++ b/byos/modern-data-warehousing/deploy/BYOS-deployAll.ps1
@@ -2,8 +2,8 @@
 
 param(
     [string]$teamCount = "1",
-    [string]$DeploymentTemplateFile = "$PSScriptRoot\ARM\DeployMDWOpenHackLab.json",
-    [string]$DeploymentParameterFile = "$PSScriptRoot\ARM\DeployMDWOpenHackLab.parameters.json",
+    [string]$DeploymentTemplateFile = (Join-Path -Path $PSScriptRoot -ChildPath "\ARM\DeployMDWOpenHackLab.json"),
+    [string]$DeploymentParameterFile = (Join-Path -Path $PSScriptRoot -ChildPath "\ARM\DeployMDWOpenHackLab.parameters.json"),
     [string]$Location = "eastus",
     [securestring]$SqlAdminLoginPassword,
     [securestring]$VMAdminPassword


### PR DESCRIPTION
Following this deployment instructions: https://github.com/microsoft/OpenHack/blob/main/byos/modern-data-warehousing/deployment.md

Running the script (using default params) using a unix based FS returns the following error: 
*Could not find file '/home/oliver/src/OpenHack/byos/modern-data-warehousing/deploy\ARM\DeployMDWOpenHackLab.json'.*

I propose to use the correct path concatination.