### PR TITLE
Update DeployMDWOpenHackLab.json

### DIFF
--- a/byos/modern-data-warehousing/deploy/ARM/DeployMDWOpenHackLab.json
+++ b/byos/modern-data-warehousing/deploy/ARM/DeployMDWOpenHackLab.json
@@ -78,7 +78,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://openhackguides.blob.core.windows.net/mdw-templates-tmp/DeployMDWOpenHackLab.json",
+                    "uri": "https://openhackpublic.blob.core.windows.net/modern-data-warehousing/DeployMDWOpenHackLab.json",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {


### PR DESCRIPTION
updates to force Windows Server 2022 and SQL Server 2022. This is the version that supports the Edge browser.