### PR TITLE
Container Hack - Update dockerfile to add permissions for sql_data_init.sh

### DIFF
--- a/byos/containers/deploy/dataload/Dockerfile
+++ b/byos/containers/deploy/dataload/Dockerfile
@@ -4,4 +4,5 @@ COPY data_load data_load
 COPY sql_data_init.sh .
 COPY MYDrivingDB.sql .
 
+RUN chmod +x ./sql_data_init.sh
 ENTRYPOINT [ "/bin/bash","-c", "./sql_data_init.sh -s $SQLFQDN -u $SQLUSER -p $SQLPASS -d $SQLDB"]


### PR DESCRIPTION
This is for the container hack BYOS. The dataload for the SQL server fails. When the ACI spins up, it doesn't have permission to run the sql init script. Adding permissions for the SQL init script in the docker file