### PR TITLE
Fix the error vm image URN

### DIFF
--- a/byos/containers/deploy/deploy.sh
+++ b/byos/containers/deploy/deploy.sh
@@ -179,7 +179,7 @@ then
 fi
 
 # Create VM
-az vm create -n internal-vm -g $teamRG --admin-username azureuser --generate-ssh-keys --public-ip-address "" --image UbuntuLTS --vnet-name vnet --subnet vm-subnet
+az vm create -n internal-vm -g $teamRG --admin-username azureuser --generate-ssh-keys --public-ip-address "" --image Ubuntu2204 --vnet-name vnet --subnet vm-subnet
 
 if [ $? == 0 ];
 then


### PR DESCRIPTION
The image URN has changed from the "UbuntuLTS" to "Ubuntu2204".
Invalid image "UbuntuLTS". Use a valid image URN, custom image name, custom image id, VHD blob URI, or pick an image from ['CentOS85Gen2', 'Debian11', 'FlatcarLinuxFreeGen2', 'OpenSuseLeap154Gen2', 'RHELRaw8LVMGen2', 'SuseSles15SP3', 'Ubuntu2204', 'Win2022Datacenter', 'Win2022AzureEditionCore', 'Win2019Datacenter', 'Win2016Datacenter', 'Win2012R2Datacenter', 'Win2012Datacenter', 'Win2008R2SP1']. See vm create -h for more information on specifying an image.