### PR TITLE
Update Dockerfile

### DIFF
--- a/byos/containers/deploy/dataload/Dockerfile
+++ b/byos/containers/deploy/dataload/Dockerfile
@@ -4,4 +4,7 @@ COPY data_load data_load
 COPY sql_data_init.sh .
 COPY MYDrivingDB.sql .
 
+USER root 
+RUN ["chmod", "+x", "./sql_data_init.sh"]
+
 ENTRYPOINT [ "/bin/bash","-c", "./sql_data_init.sh -s $SQLFQDN -u $SQLUSER -p $SQLPASS -d $SQLDB"]


### PR DESCRIPTION
Fixes #133

[Workaround for existing deployments]

Create a new image from the original and copy the file and set permissions into the new image
or
Get the code for dataload and create a new image

add 
```
USER root
RUN ["chmod", "+x", "./sql_data_init.sh"]
```
To the Dockerfile

This will run a command to eliminate the `permission denied` error that happens when trying to run the dataload image after environment creation for not having execute permission on `sql_data_init`.